### PR TITLE
nodeTreeToSketchGroup: Sorts children nodes by z-index so that lower z-indexes are added to the group first

### DIFF
--- a/html2asketch/nodeTreeToSketchGroup.js
+++ b/html2asketch/nodeTreeToSketchGroup.js
@@ -18,19 +18,13 @@ export default function nodeTreeToSketchGroup(node, options) {
       .filter(node => isNodeVisible(node))
       // sort the children by computed z-index so that nodes with lower z-indexes are added
       // to the group first, "beneath" those with higher z-indexes
-      .sort(function(a, b) {
+      .sort((a, b) => {
         const computedA = getComputedStyle(a).zIndex,
           computedB = getComputedStyle(b).zIndex,
           zIndexA = isNaN(computedA) ? 0 : +computedA,
           zIndexB = isNaN(computedB) ? 0 : +computedB;
 
-        if (zIndexB < zIndexA) {
-          return 1;
-        }
-        if (zIndexA < zIndexB) {
-          return -1;
-        }
-        return 0;
+        return zIndexA - zIndexB;
       })
       .forEach(childNode => {
         layers.push(nodeTreeToSketchGroup(childNode, options));

--- a/html2asketch/nodeTreeToSketchGroup.js
+++ b/html2asketch/nodeTreeToSketchGroup.js
@@ -18,15 +18,16 @@ export default function nodeTreeToSketchGroup(node, options) {
       .filter(node => isNodeVisible(node))
       // sort the children by computed z-index so that nodes with lower z-indexes are added
       // to the group first, "beneath" those with higher z-indexes
-      .sort(function(a,b){
-        var computedA = getComputedStyle(a).zIndex,
-            computedB = getComputedStyle(b).zIndex,
-            zIndexA = isNaN(computedA) ? 0 : +computedA,
-            zIndexB = isNaN(computedB) ? 0 : +computedB;
-        if ( zIndexB < zIndexA ){
+      .sort(function(a, b) {
+        const computedA = getComputedStyle(a).zIndex,
+          computedB = getComputedStyle(b).zIndex,
+          zIndexA = isNaN(computedA) ? 0 : +computedA,
+          zIndexB = isNaN(computedB) ? 0 : +computedB;
+
+        if (zIndexB < zIndexA) {
           return 1;
         }
-        if ( zIndexA < zIndexB ){
+        if (zIndexA < zIndexB) {
           return -1;
         }
         return 0;

--- a/html2asketch/nodeTreeToSketchGroup.js
+++ b/html2asketch/nodeTreeToSketchGroup.js
@@ -16,6 +16,21 @@ export default function nodeTreeToSketchGroup(node, options) {
     // Recursively collect child groups for child nodes
     Array.from(node.children)
       .filter(node => isNodeVisible(node))
+      // sort the children by computed z-index so that nodes with lower z-indexes are added
+      // to the group first, "beneath" those with higher z-indexes
+      .sort(function(a,b){
+        var computedA = getComputedStyle(a).zIndex,
+            computedB = getComputedStyle(b).zIndex,
+            zIndexA = isNaN(computedA) ? 0 : +computedA,
+            zIndexB = isNaN(computedB) ? 0 : +computedB;
+        if ( zIndexB < zIndexA ){
+          return 1;
+        }
+        if ( zIndexA < zIndexB ){
+          return -1;
+        }
+        return 0;
+      })
       .forEach(childNode => {
         layers.push(nodeTreeToSketchGroup(childNode, options));
 


### PR DESCRIPTION
Continuation of https://github.com/html-sketchapp/html-sketchapp/pull/158