### PR TITLE
Apply floating numbers on lineHeight values

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -290,7 +290,7 @@ export default function nodeToSketchLayers(node, options) {
   const textStyle = new TextStyle({
     fontFamily,
     fontSize: parseInt(fontSize, 10),
-    lineHeight: lineHeight !== 'normal' ? parseInt(lineHeight, 10) : undefined,
+    lineHeight: lineHeight !== 'normal' ? parseFloat(lineHeight) : undefined,
     letterSpacing: letterSpacing !== 'normal' ? parseFloat(letterSpacing) : undefined,
     fontWeight: parseFontWeight(fontWeight),
     color,


### PR DESCRIPTION
SketchApp accepts one decimal digit in lineHeight value. If the source page uses em values, the converted lineHeight value can appear more accurate when applying parseFloat.