### PR TITLE
Use debugDescription of NSData to keep compatibility with xcode 11+

### DIFF
--- a/asketch2sketch/helpers/fixImageFill.js
+++ b/asketch2sketch/helpers/fixImageFill.js
@@ -20,7 +20,7 @@ function getImageDataFromUrl(url) {
 
   const firstByte = fetchedData
     .subdataWithRange(NSMakeRange(0, 1))
-    .description();
+    .debugDescription();
 
   // Check for first byte. Must use non-type-exact matching (!=).
   // 0xFF = JPEG, 0x89 = PNG, 0x47 = GIF, 0x49 = TIFF, 0x4D = TIFF


### PR DESCRIPTION
From xcode 11, the format returned by the `NSData` object's `decription` method has changed. This breaks loading extental images. The responsible function returns `IMG_UNSUPPORTED` code which results in displaying the error image instead of the correct one downloaded from external resources.

Previous format:
`"<3c>"`

Current format:
`"{length =1, bytes = 0x3c}"`

To mitigate the issue `debugDescription` method might be used. It returns same format as `description` in previous versions of xcode. Most of the time `debugDescription` uses `description` so this change is compatible with xcode < 11. Unfortunately official [documentation](https://developer.apple.com/documentation/foundation/nsdata/1412579-description?language=objc) is not updated.

Since both functions are rather for debugging purposes, I think this change is not going to worsen the stability of the library (it's just as bad 😅))

Reference:
https://developer.apple.com/forums/thread/119111