### PR TITLE
Use updated sketchapp-json-plugin

### DIFF
--- a/asketch2sketch/asketch2sketch.js
+++ b/asketch2sketch/asketch2sketch.js
@@ -1,6 +1,6 @@
 import UI from 'sketch/ui';
 import {SharedStyle} from 'sketch/dom';
-import {fromSJSONDictionary} from 'sketchapp-json-plugin';
+import {fromSJSONDictionary} from '@brainly/sketchapp-json-plugin';
 import {fixTextLayer, fixSharedTextStyle} from './helpers/fixFont';
 import fixImageFillsInLayer from './helpers/fixImageFill';
 import fixBitmap from './helpers/fixBitmap';

--- a/asketch2sketch/helpers/fixFont.js
+++ b/asketch2sketch/helpers/fixFont.js
@@ -1,7 +1,7 @@
 // taken from https://github.com/airbnb/react-sketchapp/blob/master/src/jsonUtils/hacksForJSONImpl.js
 import {generateID, makeColorFromCSS} from './utils';
 import {TextAlignment} from 'sketch-constants';
-import {toSJSON} from 'sketchapp-json-plugin';
+import {toSJSON} from '@brainly/sketchapp-json-plugin';
 import findFont from './findFont';
 import getSketchVersion from './getSketchVersion';
 

--- a/asketch2sketch/helpers/fixSVG.js
+++ b/asketch2sketch/helpers/fixSVG.js
@@ -1,4 +1,4 @@
-import {toSJSON} from 'sketchapp-json-plugin';
+import {toSJSON} from '@brainly/sketchapp-json-plugin';
 import {replaceProperties} from './utils';
 
 function makeNativeSVGLayer(layer) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -991,6 +991,15 @@
         }
       }
     },
+    "@brainly/sketchapp-json-plugin": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@brainly/sketchapp-json-plugin/-/sketchapp-json-plugin-0.1.3.tgz",
+      "integrity": "sha512-9Pk8rQ20sdKYO/9GcxuZma9AcQ6b5qJDcRVtciQDxHS/MWuy7BRW/dCZCUzJMxoeYgsITd8L8QiwUyn++4pzhQ==",
+      "requires": {
+        "invariant": "^2.2.2",
+        "sketchapp-json-flow-types": "^0.0.2"
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -5281,7 +5290,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5302,12 +5312,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5322,17 +5334,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5449,7 +5464,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5461,6 +5477,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5475,6 +5492,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5482,12 +5500,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5506,6 +5526,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5586,7 +5607,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5598,6 +5620,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5683,7 +5706,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5719,6 +5743,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5738,6 +5763,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5781,12 +5807,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9958,15 +9986,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/sketchapp-json-flow-types/-/sketchapp-json-flow-types-0.0.2.tgz",
       "integrity": "sha1-ImSW559qOEW4kCHWZrCQq0VY19A="
-    },
-    "sketchapp-json-plugin": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/sketchapp-json-plugin/-/sketchapp-json-plugin-0.1.2.tgz",
-      "integrity": "sha512-DnJZOWiBERwvCxZkr5cbM2UrkBXpdatykYqdJs61qZDmgciOzwd0SLBxKJzDJFYXZrAdDVtTDGFAn0JAwAhS4w==",
-      "requires": {
-        "invariant": "^2.2.2",
-        "sketchapp-json-flow-types": "^0.0.2"
-      }
     },
     "skpm": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     ]
   },
   "dependencies": {
+    "@brainly/sketchapp-json-plugin": "^0.1.3",
     "murmur2js": "^1.0.0",
     "normalize-css-color": "^1.0.2",
-    "sketch-constants": "^1.1.0",
-    "sketchapp-json-plugin": "^0.1.2"
+    "sketch-constants": "^1.1.0"
   },
   "main": "build/html2asketch/index",
   "typings": "typings/",


### PR DESCRIPTION
## What?

Purpose of this change is to replace `sketchapp-json-plugin` with forked version. Original plugin has fixes to Sketch >= 64 but it's not being published any more. We replace [sketchapp-json-plugin](https://www.npmjs.com/package/sketchapp-json-plugin) with forked and recently published version  [@brainly/sketchapp-json-plugin](https://www.npmjs.com/package/@brainly/sketchapp-json-plugin).