### PR TITLE
Linear gradient: support all angles

### DIFF
--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -7,7 +7,7 @@ export default function convertAngleToFromAndTo(angle) {
       return Number.NaN;
     }
 
-    const value = parseFloat(match[1]) + ;
+    const value = parseFloat(match[1]) + 0;
     const unit = match[2];
 
     switch (unit) {

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -1,39 +1,52 @@
 // Keep this pure for easy testing in the future.
 export default function convertAngleToFromAndTo(angle) {
-  // default 180deg
-  const from = {x: 0.5, y: 0};
-  const to = {x: 0.5, y: 1};
+  function convertAngleInDegreesToFromAndTo(degrees) {
+    // we begin "from" (0,0) and have a circle (returned as "to") with starting from point at (1,0) for 0deg (to right)
+    // default 0deg
+    const from = {x: 0, y: 0};
+    const to = {x: 1, y: 0};
 
-  // Learn math or find someone smarter to figure this out correctly
-  switch (angle) {
-    case 'to top':
-    case '360deg':
-    case '0deg':
-      from.y = 1;
-      to.y = 0;
-      break;
-    case 'to right':
-    case '90deg':
-      from.x = 0;
-      from.y = 0.5;
-      to.x = 1;
-      to.y = 0.5;
-      break;
-    case 'to left':
-    case '270deg':
-      from.x = 1;
-      from.y = 0.5;
-      to.x = 0;
-      to.y = 0.5;
-      break;
-    case 'to bottom':
-    case '180deg':
-    default:
-      break;
+    if (degrees === 0) {
+      return {from, to};
+    }
+
+    // sin() and cos() needs radians to work with
+    const angleInRadians = degrees * (Math.PI / 180);
+
+    // calculate circle's (x,y) wich is sin nad cos of given radians
+    // we support precision to make things human readable
+    const precision = 2;
+    let x = Number.parseFloat(Math.cos(angleInRadians).toFixed(precision));
+    let y = Number.parseFloat(Math.sin(angleInRadians).toFixed(precision));
+
+    // convert -0 to +0, sin() and cos() may return -0 wich can lead to some miss-calcualtions
+    x += 0;
+    y += 0;
+
+    return {
+      from,
+      to: {x: x,y: y}
+    };
   }
+  
+  // we need angle to be a float number
+  const degrees = Number.parseFloat(angle);
 
-  return {
-    from,
-    to,
-  };
+  // but if we don't have a number we also support some strings
+  if (Number.isNaN(degrees)) {
+    switch (angle) {
+      case 'to right':
+        return convertAngleInDegreesToFromAndTo(0);
+      case 'to bottom':
+        return convertAngleInDegreesToFromAndTo(90);
+      case 'to left':
+        return convertAngleInDegreesToFromAndTo(180);
+      case 'to top':
+        return convertAngleInDegreesToFromAndTo(270);
+      default:
+        throw TypeError('Incorrect angle.');
+    }
+  }
+  
+  return convertAngleInDegreesToFromAndTo(degrees);
 }

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -23,12 +23,13 @@ export default function convertAngleToFromAndTo(angle) {
         return Number.NaN;
     }
   }
-  
+
   function convertRadiansToFromAndTo(radians) {
-    // we begin "from" (0,0) and have a circle (returned as "to") with starting from point at (0,-1) for 0deg (to bottom)
+    // we begin "from" (0,0) and have a circle (returned as "to") 
+    // with starting from point at (0,-1) for 0deg (to bottom)
     // default 0deg
-    const from = { x: 0, y: 0 };
-    const to = { x: 0, y: -1 };
+    const from = {x: 0, y: 0};
+    const to = {x: 0, y: -1};
 
     if (radians === 0) {
       return {from, to};
@@ -50,7 +51,7 @@ export default function convertAngleToFromAndTo(angle) {
 
     return {
       from,
-      to: { x, y },
+      to: {x, y},
     };
   }
 
@@ -72,7 +73,7 @@ export default function convertAngleToFromAndTo(angle) {
         return convertRadiansToFromAndTo(parseAngleToRadians('180deg'));
       case 'to left top':
         return convertRadiansToFromAndTo(parseAngleToRadians('225deg'));
-      case 'to right':
+      case 'to left':
         return convertRadiansToFromAndTo(parseAngleToRadians('270deg'));
       case 'to left bottom':
         return convertRadiansToFromAndTo(parseAngleToRadians('315deg'));

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -26,54 +26,54 @@ export default function convertAngleToFromAndTo(angle, width, height) {
 
   function fixFloat(float) {
     const precistion = 5;
-  
+
     return Number.parseFloat(float.toFixed(precistion)) + 0;
   }
-  
+
   function calculateFromAndTo({angleInRadians, width, height}) {
     const angle180degInRadians = parseAngleToRadians('180deg');
-  
+
     // calculate gradient height
     const gradientHeight = Math.abs(width * Math.sin(angleInRadians)) + Math.abs(height * Math.cos(angleInRadians));
-  
+
     // calculate is which is half of gradient times cos/sin of angle
     const toX = fixFloat((gradientHeight / 2) * Math.sin(angleInRadians));
     const toY = fixFloat((gradientHeight / 2) * Math.cos(angleInRadians));
-  
+
     // calculate is which is half of gradient times cos/sin of angle
     const fromX = fixFloat((gradientHeight / 2) * Math.sin(angleInRadians + angle180degInRadians));
     const fromY = fixFloat((gradientHeight / 2) * Math.cos(angleInRadians + angle180degInRadians));
-  
+
     return {fromX, fromY, toX, toY};
   }
-  
+
   function normalizeDimensionForSketch({fromX, fromY, toX, toY, width, height}) {
     const response = {from: {x: fromX, y: fromY}, to: {x: toX, y: toY}};
-  
+
     // y axis shoulbe be 1 if equal to height
     response.from.y /= height;
     response.to.y /= height;
-  
+
     // x axis shoulbe be 1 if equal to width
     response.from.x /= width;
     response.to.x /= width;
-  
+
     // y axis is reflected downwards in sketch
     response.from.y *= -1;
     response.to.y *= -1;
-  
+
     // let's fixFloat
     response.from.x = fixFloat(response.from.x);
     response.from.y = fixFloat(response.from.y);
     response.to.x = fixFloat(response.to.x);
     response.to.y = fixFloat(response.to.y);
-  
+
     // (0,0) is in (0.5,0.5), we need to move whole axis
     response.from.x += 0.5;
     response.from.y += 0.5;
     response.to.x += 0.5;
     response.to.y += 0.5;
-  
+
     return response;
   }
 

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -37,7 +37,7 @@ export default function convertAngleToFromAndTo(angle) {
 
     // sin() and cos() needs radians to work with
     // and we need to rotate the whole thing by 90deg so we support "to bottom" as default
-    const angleInRadians = radians + parseAngleToRadians('-270deg');
+    const angleInRadians = radians - parseAngleToRadians('90deg');
 
     // calculate circle's (x,y) wich is sin nad cos of given radians
     // we support precision to make things human readable

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -69,8 +69,8 @@ export default function convertAngleToFromAndTo(angle, width, height) {
     response.to.x = fixFloat(response.to.x);
     response.to.y = fixFloat(response.to.y);
 
-    // (0.5, 0.5) is the shift of the gradient line in sketch, 
-    // as we want gradient line to always go through the 
+    // (0.5, 0.5) is the shift of the gradient line in sketch,
+    // as we want gradient line to always go through the
     // center of the shape in both axis, so we need to move whole axis
     response.from.x += 0.5;
     response.from.y += 0.5;

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -25,10 +25,10 @@ export default function convertAngleToFromAndTo(angle) {
 
     return {
       from,
-      to: {x: x,y: y}
+      to: {x, y},
     };
   }
-  
+
   // we need angle to be a float number
   const degrees = Number.parseFloat(angle);
 
@@ -47,6 +47,6 @@ export default function convertAngleToFromAndTo(angle) {
         throw TypeError('Incorrect angle.');
     }
   }
-  
+
   return convertAngleInDegreesToFromAndTo(degrees);
 }

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -55,7 +55,7 @@ export default function convertAngleToFromAndTo(angle, width, height) {
     response.from.y /= height;
     response.to.y /= height;
 
-    // x axis shoul be proportional to width
+    // x axis should be proportional to width
     response.from.x /= width;
     response.to.x /= width;
 

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -77,38 +77,44 @@ export default function convertAngleToFromAndTo(angle, width, height) {
     return response;
   }
 
+  const normalizedAngle = angle.trim().toLowerCase();
+
   // we need angle to be a float number
-  let angleInRadians = parseAngleToRadians(angle);
+  let angleInRadians = parseAngleToRadians(normalizedAngle);
 
   // but if we don't have a number we also support some strings
   if (Number.isNaN(angleInRadians)) {
-    switch (angle.toLowerCase()) {
+    switch (normalizedAngle) {
       case 'to top':
         angleInRadians = parseAngleToRadians('0deg');
         break;
       case 'to right top':
+      case 'to top right':
         angleInRadians = parseAngleToRadians('45deg');
         break;
       case 'to right':
         angleInRadians = parseAngleToRadians('90deg');
         break;
       case 'to right bottom':
+      case 'to bottom right':
         angleInRadians = parseAngleToRadians('135deg');
         break;
       case 'to bottom':
         angleInRadians = parseAngleToRadians('180deg');
         break;
       case 'to left bottom':
+      case 'to bottom left':
         angleInRadians = parseAngleToRadians('225deg');
         break;
       case 'to left':
         angleInRadians = parseAngleToRadians('270deg');
         break;
       case 'to left top':
+      case 'to top left':
         angleInRadians = parseAngleToRadians('315deg');
         break;
       default:
-        throw TypeError('Incorrect angle.');
+        throw TypeError(`Incorrect angle: ${angle}`);
     }
   }
 

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -25,7 +25,7 @@ export default function convertAngleToFromAndTo(angle, width, height) {
   }
 
   function fixFloat(float) {
-    const precistion = 5;
+    const precistion = 7;
 
     // round with precision and convert -0 to +0
     return Number.parseFloat(float.toFixed(precistion)) + 0;
@@ -51,11 +51,11 @@ export default function convertAngleToFromAndTo(angle, width, height) {
   function normalizeDimensionsForSketch({from, to, width, height}) {
     const response = {from: {...from}, to: {...to}};
 
-    // y axis shoulbe be 1 if equal to height
+    // y axis should be proportional to height
     response.from.y /= height;
     response.to.y /= height;
 
-    // x axis shoulbe be 1 if equal to width
+    // x axis shoul be proportional to width
     response.from.x /= width;
     response.to.x /= width;
 

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -1,17 +1,42 @@
 // Keep this pure for easy testing in the future.
 export default function convertAngleToFromAndTo(angle) {
-  function convertAngleInDegreesToFromAndTo(degrees) {
-    // we begin "from" (0,0) and have a circle (returned as "to") with starting from point at (1,0) for 0deg (to right)
-    // default 0deg
-    const from = {x: 0, y: 0};
-    const to = {x: 1, y: 0};
+  function parseAngleToRadians(angle) {
+    const match = angle.match(/^(-?(?:\d+)?(?:\.\d+)?)(deg|grad|rad|turn)$/);
 
-    if (degrees === 0) {
+    if (!match) {
+      return Number.NaN;
+    }
+
+    const value = parseFloat(match[1]) + ;
+    const unit = match[2];
+
+    switch (unit) {
+      case 'deg':
+        return value * (Math.PI / 180);
+      case 'grad':
+        return value * (Math.PI / 200);
+      case 'rad':
+        return value;
+      case 'turn':
+        return value * 2 * Math.PI;
+      default:
+        return Number.NaN;
+    }
+  }
+  
+  function convertRadiansToFromAndTo(radians) {
+    // we begin "from" (0,0) and have a circle (returned as "to") with starting from point at (0,-1) for 0deg (to bottom)
+    // default 0deg
+    const from = { x: 0, y: 0 };
+    const to = { x: 0, y: -1 };
+
+    if (radians === 0) {
       return {from, to};
     }
 
     // sin() and cos() needs radians to work with
-    const angleInRadians = degrees * (Math.PI / 180);
+    // and we need to rotate the whole thing by 90deg so we support "to bottom" as default
+    const angleInRadians = radians + parseAngleToRadians('-270deg');
 
     // calculate circle's (x,y) wich is sin nad cos of given radians
     // we support precision to make things human readable
@@ -25,28 +50,36 @@ export default function convertAngleToFromAndTo(angle) {
 
     return {
       from,
-      to: {x, y},
+      to: { x, y },
     };
   }
 
   // we need angle to be a float number
-  const degrees = Number.parseFloat(angle);
+  const radians = parseAngleToRadians(angle);
 
   // but if we don't have a number we also support some strings
-  if (Number.isNaN(degrees)) {
-    switch (angle) {
-      case 'to right':
-        return convertAngleInDegreesToFromAndTo(0);
+  if (Number.isNaN(radians)) {
+    switch (angle.toLowerCase()) {
       case 'to bottom':
-        return convertAngleInDegreesToFromAndTo(90);
-      case 'to left':
-        return convertAngleInDegreesToFromAndTo(180);
+        return convertRadiansToFromAndTo(parseAngleToRadians('0deg'));
+      case 'to right bottom':
+        return convertRadiansToFromAndTo(parseAngleToRadians('45deg'));
+      case 'to right':
+        return convertRadiansToFromAndTo(parseAngleToRadians('90deg'));
+      case 'to right top':
+        return convertRadiansToFromAndTo(parseAngleToRadians('135deg'));
       case 'to top':
-        return convertAngleInDegreesToFromAndTo(270);
+        return convertRadiansToFromAndTo(parseAngleToRadians('180deg'));
+      case 'to left top':
+        return convertRadiansToFromAndTo(parseAngleToRadians('225deg'));
+      case 'to right':
+        return convertRadiansToFromAndTo(parseAngleToRadians('270deg'));
+      case 'to left bottom':
+        return convertRadiansToFromAndTo(parseAngleToRadians('315deg'));
       default:
         throw TypeError('Incorrect angle.');
     }
   }
 
-  return convertAngleInDegreesToFromAndTo(degrees);
+  return convertRadiansToFromAndTo(radians);
 }

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -27,6 +27,7 @@ export default function convertAngleToFromAndTo(angle, width, height) {
   function fixFloat(float) {
     const precistion = 5;
 
+    // round with precision and convert -0 to +0
     return Number.parseFloat(float.toFixed(precistion)) + 0;
   }
 
@@ -36,19 +37,19 @@ export default function convertAngleToFromAndTo(angle, width, height) {
     // calculate gradient height
     const gradientHeight = Math.abs(width * Math.sin(angleInRadians)) + Math.abs(height * Math.cos(angleInRadians));
 
-    // calculate is which is half of gradient times cos/sin of angle
+    // calculate to which is half of gradient times cos/sin of angle
     const toX = fixFloat((gradientHeight / 2) * Math.sin(angleInRadians));
     const toY = fixFloat((gradientHeight / 2) * Math.cos(angleInRadians));
 
-    // calculate is which is half of gradient times cos/sin of angle
+    // calculate from which is half of gradient times cos/sin of angle + 180deg
     const fromX = fixFloat((gradientHeight / 2) * Math.sin(angleInRadians + angle180degInRadians));
     const fromY = fixFloat((gradientHeight / 2) * Math.cos(angleInRadians + angle180degInRadians));
 
-    return {fromX, fromY, toX, toY};
+    return {from: {x: fromX, y: fromY}, to: {x: toX, y: toY}};
   }
 
-  function normalizeDimensionForSketch({fromX, fromY, toX, toY, width, height}) {
-    const response = {from: {x: fromX, y: fromY}, to: {x: toX, y: toY}};
+  function normalizeDimensionsForSketch({from, to, width, height}) {
+    const response = {from: {...from}, to: {...to}};
 
     // y axis shoulbe be 1 if equal to height
     response.from.y /= height;
@@ -118,7 +119,7 @@ export default function convertAngleToFromAndTo(angle, width, height) {
     }
   }
 
-  const mathDimensions = calculateFromAndTo({angleInRadians, width, height});
+  const {from, to} = calculateFromAndTo({angleInRadians, width, height});
 
-  return normalizeDimensionForSketch({...mathDimensions, width, height});
+  return normalizeDimensionsForSketch({from, to, width, height});
 }

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -69,7 +69,9 @@ export default function convertAngleToFromAndTo(angle, width, height) {
     response.to.x = fixFloat(response.to.x);
     response.to.y = fixFloat(response.to.y);
 
-    // (0,0) is in (0.5,0.5), we need to move whole axis
+    // (0.5, 0.5) is the shift of the gradient line in sketch, 
+    // as we want gradient line to always go through the 
+    // center of the shape in both axis, so we need to move whole axis
     response.from.x += 0.5;
     response.from.y += 0.5;
     response.to.x += 0.5;

--- a/html2asketch/helpers/convertAngleToFromAndTo.js
+++ b/html2asketch/helpers/convertAngleToFromAndTo.js
@@ -25,7 +25,7 @@ export default function convertAngleToFromAndTo(angle) {
   }
 
   function convertRadiansToFromAndTo(radians) {
-    // we begin "from" (0,0) and have a circle (returned as "to") 
+    // we begin "from" (0,0) and have a circle (returned as "to")
     // with starting from point at (0,-1) for 0deg (to bottom)
     // default 0deg
     const from = {x: 0, y: 0};

--- a/html2asketch/model/style.js
+++ b/html2asketch/model/style.js
@@ -14,8 +14,9 @@ class Style {
     this._fills.push(makeColorFill(color, opacity));
   }
 
-  addGradientFill({angle, stops}) {
-    const {from, to} = convertAngleToFromAndTo(angle);
+  addGradientFill({angle, stops}, width, height) {
+    // width and height stand for trimmed 2d canvas of any polygon to fill gradient with
+    const {from, to} = convertAngleToFromAndTo(angle, width, height);
 
     this._fills.push({
       _class: 'fill',

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -253,7 +253,7 @@ export default function nodeToSketchLayers(node, options) {
           break;
         }
         case 'LinearGradient':
-          style.addGradientFill(backgroundImageResult.value);
+          style.addGradientFill(backgroundImageResult.value, width, height);
           break;
         default:
           // Unsupported types:


### PR DESCRIPTION
Relates to #11

I hope this is ok, but is there a reason to start in (0.5, 0)? If not to simplyfy math, I'm starting in (0,0).
Also for this logic to work i assume that 0deg is equal "to right". I can rotate everything by 90deg so default 0deg would be "to bottom" like in original file.

Tested it in console and should work fine I think. I did not run tests by `npm test` nor in sketch (working on windows).

@kdzwinel Is precision of `.toFixed(2)` ok?