### PR TITLE
Change closest matching font algorithm

### DIFF
--- a/asketch2sketch/helpers/findFont.js
+++ b/asketch2sketch/helpers/findFont.js
@@ -185,8 +185,6 @@ const findFont = style => {
   // and there is another font heavier font - black, with 0.8 weight, the latter will be picked.
   const fontWeightRange = WEIGHT_MAP[fontWeight];
 
-  console.log(`fontWeight: ${fontWeight} fontWeightRange: ${fontWeightRange}, fontNames: ${fontNames},  fontNames.length: ${fontNames.length} `);
-
   for (let i = 0; i < fontNames.length; i += 1) {
     const match = NSFont.fontWithName_size(fontNames[i], fontSize);
 

--- a/asketch2sketch/helpers/findFont.js
+++ b/asketch2sketch/helpers/findFont.js
@@ -28,6 +28,18 @@ const FONT_WEIGHTS = {
   '900': NSFontWeightBlack,
 };
 
+const WEIGHT_MAP = {
+  [NSFontWeightUltraLight]: [-1.0, -0.70],
+  [NSFontWeightThin]: [-0.70, -0.45],
+  [NSFontWeightLight]: [-0.45, -0.10],
+  [NSFontWeightRegular]: [-0.10, 0.10],
+  [NSFontWeightMedium]: [0.10, 0.27],
+  [NSFontWeightSemibold]: [0.27, 0.35],
+  [NSFontWeightBold]: [0.35, 0.50],
+  [NSFontWeightHeavy]: [0.50, 0.60],
+  [NSFontWeightBlack]: [0.60, 1.0],
+};
+
 const isItalicFont = font => {
   const traits = font.fontDescriptor().objectForKey(NSFontTraitsAttribute);
   const symbolicTraits = traits[NSFontSymbolicTrait].unsignedIntValue();
@@ -174,6 +186,7 @@ const findFont = style => {
     if (isItalic === isItalicFont(match) && isCondensed === isCondensedFont(match)) {
       const testWeight = weightOfFont(match);
 
+      console.log(`Find closes font, fontWeight: ${fontWeight}, match: ${match}, testWeight: ${testWeight},  fontName: '${fontNames[i]}', fontSize: ${fontSize}`);
       if (Math.abs(testWeight - fontWeight) < Math.abs(closestWeight - fontWeight)) {
         font = match;
 

--- a/asketch2sketch/helpers/findFont.js
+++ b/asketch2sketch/helpers/findFont.js
@@ -71,6 +71,7 @@ const weightOfFont = font => {
           .toLowerCase()
           .endsWith(w)
       ) {
+
         return FONT_WEIGHTS[w];
       }
     }
@@ -178,7 +179,13 @@ const findFont = style => {
   }
 
   // Get the closest font that matches the given weight for the fontFamily
-  let closestWeight = Infinity;
+  // We don't break the loop even if we find matching element.
+  // The heaviest matching element should win.
+  // E.g. If weight of extra bold font found in the system is 0.61 and would match NSFontWeightBlack
+  // and there is another font heavier font - black, with 0.8 weight, the latter will be picked.
+  const fontWeightRange = WEIGHT_MAP[fontWeight];
+
+  console.log(`fontWeight: ${fontWeight} fontWeightRange: ${fontWeightRange}, fontNames: ${fontNames},  fontNames.length: ${fontNames.length} `);
 
   for (let i = 0; i < fontNames.length; i += 1) {
     const match = NSFont.fontWithName_size(fontNames[i], fontSize);
@@ -186,11 +193,8 @@ const findFont = style => {
     if (isItalic === isItalicFont(match) && isCondensed === isCondensedFont(match)) {
       const testWeight = weightOfFont(match);
 
-      console.log(`Find closes font, fontWeight: ${fontWeight}, match: ${match}, testWeight: ${testWeight},  fontName: '${fontNames[i]}', fontSize: ${fontSize}`);
-      if (Math.abs(testWeight - fontWeight) < Math.abs(closestWeight - fontWeight)) {
+      if (testWeight >= fontWeightRange[0] && testWeight < fontWeightRange[1]) {
         font = match;
-
-        closestWeight = testWeight;
       }
     }
   }

--- a/asketch2sketch/helpers/findFont.js
+++ b/asketch2sketch/helpers/findFont.js
@@ -181,7 +181,7 @@ const findFont = style => {
   // We don't break the loop even if we find matching element.
   // The heaviest matching element should win.
   // E.g. If weight of extra bold font found in the system is 0.61 and would match NSFontWeightBlack
-  // and there is another font heavier font - black, with 0.8 weight, the latter will be picked.
+  // and there is another heavier font - black, with 0.8 weight, the latter will be picked.
   const fontWeightRange = WEIGHT_MAP[fontWeight];
 
   for (let i = 0; i < fontNames.length; i += 1) {

--- a/asketch2sketch/helpers/findFont.js
+++ b/asketch2sketch/helpers/findFont.js
@@ -177,9 +177,9 @@ const findFont = style => {
     }
   }
 
-  // Get the closest font that matches the given weight for the fontFamily
-  // We don't break the loop even if we find matching element.
-  // The heaviest matching element should win.
+  // Get the font that matches the given weight for the fontFamily.
+  // We don't break the loop even if we find matching element because
+  // the heaviest matching element should win.
   // E.g. If weight of extra bold font found in the system is 0.61 and would match NSFontWeightBlack
   // and there is another heavier font - black, with 0.8 weight, the latter will be picked.
   const fontWeightRange = WEIGHT_MAP[fontWeight];

--- a/asketch2sketch/helpers/findFont.js
+++ b/asketch2sketch/helpers/findFont.js
@@ -71,7 +71,6 @@ const weightOfFont = font => {
           .toLowerCase()
           .endsWith(w)
       ) {
-
         return FONT_WEIGHTS[w];
       }
     }


### PR DESCRIPTION
The previous implementation was based on absolute proximity between desired value and found font weight value. Depending on system and particular font this could lead to situation where wrong font was selected.

For example:
Desired font weight: `Black/Heavy - 0.62`

Font selected as closest: `Extrabold - 0.6`
Font which should have been picked: `Black - 0.8.`

Current algorithm uses range for desired font weight. Those values are taken from chromium implementation for picking desired font.

![image](https://user-images.githubusercontent.com/8572321/104334192-59c78980-54f2-11eb-885c-13e8f2b0bd6c.png)
https://chromium.googlesource.com/chromium/src/+/master/ui/gfx/platform_font_mac.mm#93

Additionally algorithm promotes the biggest font if 2 fonts are in appropriate weight range.

For example:
Desired font weight: `Black/Heavy - 0.62`

Font selected as closest: `Extrabold - 0.6001` (this matches `0.6-1` range)
Font which should have been picked: `Black - 0.8.`(this matches `0.6-1` range)

